### PR TITLE
fix: add missing return statement in scopeDistanceSphereValue

### DIFF
--- a/src/Eloquent/SpatialTrait.php
+++ b/src/Eloquent/SpatialTrait.php
@@ -191,6 +191,8 @@ trait SpatialTrait
             $geometry->toWkt(),
             $geometry->getSrid(),
         ]);
+
+        return $query;
     }
 
     public function scopeComparison($query, $geometryColumn, $geometry, $relationship)


### PR DESCRIPTION
 **Summary**
Fixes a missing return statement in the `scopeDistanceSphereValue()` method that breaks query builder method chaining.
 **Problem**
When calling `distanceSphereValue()` on a model query, any attempt to chain additional methods fails:

// This breaks
```
$results = GeometryModel::distanceSphereValue('location', $point)
    ->where('active', true)  // Error: Call to member function on null
    ->get();
```

The method modifies the query builder but doesn't return it, leaving calling code with null instead of a chainable query builder.

**Solution**
Added the missing return $query; statement on line 195, matching the implementation pattern in scopeDistanceValue() (line 148) and all other scope methods in the trait.